### PR TITLE
Misc updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ name = "rbloom"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.17.3", features = ["extension-module", "abi3-py37"] }  # stable ABI with minimum Python version 3.7
+pyo3 = { version = "0.18", features = ["extension-module", "abi3-py37"] }  # stable ABI with minimum Python version 3.7


### PR DESCRIPTION
* Update pyo3 to 0.18
* Make use of the ability to take a `Python<'_>` first argument, which py03 will automatically pass in
* Pull out some variables to simplify approx_items calculation
* Add py03 signatures to methods (these will appear in the `help` in python)
* Use PyObject.clone_ref(), which is cheaper as long as we already hold a `Python<'_>` marker
* Reduce cloning for or/and implementations, by implementing operators on references as well
* Reuse a single temp bitset in `intersection_update` when passed mulitple non-bloom items
* Add a simple `repr` implementation (maybe should include more info?)
* Added an implementation of `__bool__`, so `if my_bloom:` works like other python collections (false if empty, otherwise true)
* Some refactoring of internal BitLine struct to use a type defintion for its "words", and changed to use a vec of usize rather than bytes
* Simplify checking if hash functions are the same by matching on a tuple