### PR TITLE
Allow the saving and loading to a byte string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.19", features = ["extension-module", "abi3-py37"] }  # stable ABI with minimum Python version 3.7
+pyo3-file = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.19", features = ["extension-module", "abi3-py37"] }  # stable ABI with minimum Python version 3.7
-pyo3-file = "0.7.0"
+# pyo3-file = "0.7.0"
+pyo3-file = { git = "https://github.com/Dr-Emann/pyo3-file", branch = "push-muyqwrvqqmnt" }

--- a/rbloom.pyi
+++ b/rbloom.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Iterable, Union, final
+from typing import Any, Callable, Iterable, Union, final, Optional, BinaryIO
 
 
 @final
@@ -8,7 +8,7 @@ class Bloom:
     # false_positive_rate:  max false positive rate of the filter
     # hash_func:  optional argument, see section "Cryptographic security"
     def __init__(self, expected_items: int, false_positive_rate: float,
-                 hash_func=__builtins__.hash) -> None: ...
+                 hash_func: Callable[[Any], int]=__builtins__.hash) -> None: ...
 
     # number of buckets in the filter
     @property
@@ -24,17 +24,10 @@ class Bloom:
 
     # load from file, see section "Persistence"
     @classmethod
-    def load(cls, filepath: str, hash_func: Callable[[Any], int]) -> Bloom: ...
+    def load(cls, dest: Union[bytes, str, BinaryIO], hash_func: Callable[[Any], int]) -> Bloom: ...
 
-    # load from bytes(), see section "Persistence"
-    @classmethod
-    def load_bytes(cls, data: bytes, hash_func: Callable[[Any], int]) -> Bloom: ...
-
-    # save to file, see section "Persistence"
-    def save(self, filepath: str) -> None: ...
-
-    # save to a bytes(), see section "Persistence"
-    def save_bytes(self) -> bytes: ...
+    # save to file, file object, or return bytes, see section "Persistence"
+    def save(self, source: Optional[Union[str, BinaryIO]] = None) -> Union[bytes, None]: ...
 
     #####################################################################
     #                    ALL SUBSEQUENT METHODS ARE                     #

--- a/rbloom.pyi
+++ b/rbloom.pyi
@@ -26,8 +26,15 @@ class Bloom:
     @classmethod
     def load(cls, filepath: str, hash_func: Callable[[Any], int]) -> Bloom: ...
 
+    # load from bytes(), see section "Persistence"
+    @classmethod
+    def load_bytes(cls, data: bytes, hash_func: Callable[[Any], int]) -> Bloom: ...
+
     # save to file, see section "Persistence"
     def save(self, filepath: str) -> None: ...
+
+    # save to a bytes(), see section "Persistence"
+    def save_bytes(self) -> bytes: ...
 
     #####################################################################
     #                    ALL SUBSEQUENT METHODS ARE                     #

--- a/rbloom.pyi
+++ b/rbloom.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Iterable, Union, final, Optional, BinaryIO
+from typing import Any, Callable, Iterable, Union, final, Optional, BinaryIO, overload
 
 
 @final
@@ -27,7 +27,11 @@ class Bloom:
     def load(cls, dest: Union[bytes, str, BinaryIO], hash_func: Callable[[Any], int]) -> Bloom: ...
 
     # save to file, file object, or return bytes, see section "Persistence"
-    def save(self, source: Optional[Union[str, BinaryIO]] = None) -> Union[bytes, None]: ...
+    @overload
+    def save(self, source: Union[str, BinaryIO]) -> None: ...
+
+    @overload
+    def save(self) -> bytes: ...
 
     #####################################################################
     #                    ALL SUBSEQUENT METHODS ARE                     #

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,10 +277,9 @@ impl Bloom {
     #[classattr]
     const __hash__: Option<PyObject> = None;
 
-    /// Load from a file, see "Persistence" section in the README
+    /// Load from a file, fileobj or bytes, see "Persistence" section in the README
     #[classmethod]
     fn load(_cls: &PyType, src: PyObject, hash_func: &PyAny) -> PyResult<Bloom> {
-        // Self::load_from_read(hash_func, || File::open(filepath))
         match SaveLoadType::from_pyobject(Some(src)) {
             Ok(f) => match f {
                 SaveLoadType::Filepath(filepath) => {
@@ -297,7 +296,7 @@ impl Bloom {
         }
     }
 
-    /// Save to a file, see "Persistence" section in the README
+    /// Save to a file, fileobj or bytes, see "Persistence" section in the README
     fn save(&self, dest: Option<PyObject>) -> PyResult<PyObject> {
         match SaveLoadType::from_pyobject(dest) {
             Ok(f) => match f {

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -87,6 +87,12 @@ def test_bloom(bloom: Bloom):
             # remove the file
             os.remove(filename)
 
+        # TEST bytes PERSISTENCE
+        bloom_bytes = bloom.save_bytes()
+        assert type(bloom_bytes) == bytes
+        bloom3 = Bloom.load_bytes(bloom_bytes, bloom.hash_func)
+        assert bloom == bloom3
+
 
 def sha_based(obj):
     h = sha256(dumps(obj)).digest()

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -4,6 +4,7 @@ from rbloom import Bloom
 from hashlib import sha256
 from pickle import dumps
 import os
+import io
 
 
 def test_bloom(bloom: Bloom):
@@ -88,10 +89,19 @@ def test_bloom(bloom: Bloom):
             os.remove(filename)
 
         # TEST bytes PERSISTENCE
-        bloom_bytes = bloom.save_bytes()
+        bloom_bytes = bloom.save()
         assert type(bloom_bytes) == bytes
-        bloom3 = Bloom.load_bytes(bloom_bytes, bloom.hash_func)
+        bloom3 = Bloom.load(bloom_bytes, bloom.hash_func)
         assert bloom == bloom3
+
+        # TEST fileobj PERSISTENCE
+        fileobj = io.BytesIO()
+
+        bloom.save(fileobj)
+        fileobj.seek(0)
+
+        bloom4 = Bloom.load(fileobj, bloom.hash_func)
+        assert bloom == bloom4
 
 
 def sha_based(obj):


### PR DESCRIPTION
Implement the functions:

```
load_bytes(cls, data: bytes, hash_func: Callable[[Any], int]) -> Bloom: ...
def save_bytes(self) -> bytes: ...
```

to allow for saving and loading via Python `bytes`, for storage other than in a file.

Apologies if this is terrible Rust, I've never written Rust before today.