### PR TITLE
Slightly faster customized hash_func example

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,11 @@ to use the following example in your own code:
 from rbloom import Bloom
 from hashlib import sha256
 from pickle import dumps
+from sys import byteorder
 
 def hash_func(obj):
     h = sha256(dumps(obj)).digest()
-    return int.from_bytes(h[:16], "big") - 2**127
+    return int.from_bytes(h[:16], byteorder, signed=True)
 
 bf = Bloom(100_000_000, 0.01, hash_func)
 ```


### PR DESCRIPTION
Use `int.from_bytes(bytes_len_16, byteorder=sys.byteorder, signed=True)` to convert a 16-byte buffer to an integer in the range [-2^127, 2^127-1] with fewer in-Python operations.

A few quick `assert`s to demonstrate the correct range is generated:

```py
assert int.from_bytes(b'\x00'*16, 'big', signed=True) == 0
assert int.from_bytes(b'\xff'*16, 'big', signed=True) == -1
assert int.from_bytes(b'\x7f' + b'\xff'*15, 'big', signed=True) == (2**127-1)
assert int.from_bytes(b'\x80' + b'\x00'*15, 'big', signed=True) == (-2**127)
```