### PR TITLE
Support for buffers in load_bytes() factory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = { version = "0.21", features = [
     "extension-module",
-    "abi3-py37",
+    "abi3-py311",
 ] } # stable ABI with minimum Python version 3.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.21", features = [
     "extension-module",
     "abi3-py311",
-] } # stable ABI with minimum Python version 3.7
+] } # stable ABI with minimum Python version 3.11

--- a/rbloom.pyi
+++ b/rbloom.pyi
@@ -1,5 +1,6 @@
 import os
 from typing import Any, Callable, Iterable, Union, final
+from collections.abc import Buffer
 
 
 @final
@@ -29,7 +30,7 @@ class Bloom:
 
     # load from bytes(), see section "Persistence"
     @classmethod
-    def load_bytes(cls, data: bytes, hash_func: Callable[[Any], int]) -> Bloom: ...
+    def load_bytes(cls, data: Buffer, hash_func: Callable[[Any], int]) -> Bloom: ...
 
     # save to file, see section "Persistence"
     def save(self, filepath: Union[str, bytes, os.PathLike]) -> None: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,7 +306,7 @@ impl Bloom {
 
         let k_bytes: [u8; mem::size_of::<u64>()] = bytes[0..mem::size_of::<u64>()]
             .try_into()
-            .expect("test");
+            .expect("slice with incorrect length");
         let k = u64::from_le_bytes(k_bytes);
         let filter = BitLine::load_bytes(&bytes[mem::size_of::<u64>()..])?;
 

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -113,6 +113,22 @@ def circular_ref():
     gc.collect()
     assert weak_ref() is None
 
+def test_buffer_load():
+    bloom = Bloom(10, 0.1, hash_func=sha_based)
+    bloom.update([
+        "test",
+        "one",
+        "two",
+        "three",
+        "teststring",
+        "abacaba"
+    ])
+
+    serialized = bloom.save_bytes()
+    view = memoryview(serialized)
+    restored = Bloom.load_bytes(view, hash_func=sha_based)
+    assert bloom == restored
+
 
 def api_suite():
     assert repr(Bloom(27_000, 0.0317)) == "<Bloom size_in_bits=193960 approx_items=0.0>"
@@ -125,6 +141,8 @@ def api_suite():
     test_bloom(Bloom(2837, 0.5, hash_func=hash))
 
     circular_ref()
+
+    test_buffer_load()
 
     print('All API tests passed')
 


### PR DESCRIPTION
This PR addresses Bloom load_bytes support for all objects with[ buffer protocol](https://docs.python.org/3/c-api/buffer.html) implemented.
The problem I was trying to solve was:

- Bloom filter creation in the main process
- Passing existing filter to worker processes via Python [SharedMemory](https://docs.python.org/3/library/multiprocessing.shared_memory.html)
The `SharedMemory` instance has `.buf` member, which is `memoryview` instance. Current Bloom implementation can work only with `bytes` to load serialized filter object. It leads to additional memory copy (in addition to one inside `load` method.

After this PR Bloom filter can be constructed from any object with buffer protocol support, such as memoryview, array, bytearray, numpy array (I guess)

On a side note it bumps Python ABI compatibility requirements to 3.11. From Pyo3 documentation about [PyBuffer](https://docs.rs/pyo3/0.21.2/pyo3/buffer/struct.PyBuffer.html):

> Available on non-Py_LIMITED_API or Py_3_11 only
