### PR TITLE
fix: Mark version as a dynamic field in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
+dynamic = ["version"]
 
 
 [project.urls]


### PR DESCRIPTION
Maturin will populate the project version, but we should mark that in the pyproject.toml as a dynamic field.

See https://github.com/PyO3/maturin/issues/2390

Without this change, maturin versions 1.8+ will fail (or uv will fail to build it)